### PR TITLE
git_create_pr

### DIFF
--- a/common.rb
+++ b/common.rb
@@ -30,7 +30,7 @@ end
 def repo_owner
   @_repo_owner ||= begin
     string = `git remote -v | grep fetch | grep origin`
-    regex = /.*:(.*)\/.*/
+    regex = /.*:(.*)\/(.*)\/.*/
     match_data = string.match(regex)
     match_data.to_a.last
   end

--- a/scripts/git_create_pr
+++ b/scripts/git_create_pr
@@ -12,6 +12,6 @@ require_relative '../common.rb'
 issue_number = branch_name.to_i
 
 ensure_hub_command_exists
-execute_cmd "hub pull-request -i #{issue_number} -b #{repo_owner}:master -h #{repo_owner}:#{branch_name}"
+execute_cmd "hub --noop pull-request -i #{issue_number} -b #{repo_owner}:master -h #{repo_owner}:#{branch_name}"
 
 open_url "https://github.com/#{repo_owner}/#{repo_name}/pull/#{issue_number}"


### PR DESCRIPTION
Not responding to scenario where github requires login credentials
Along with that, saw this issue,

``````
./scripts/git_create_pr
git version 1.8.5.3
hub version 1.11.1
Warning: Issue to pull request conversion is deprecated and might not work in the future.
Error creating pull request: Not Found (HTTP 404)
Are you sure that github.com///github.com/bigbinary exists?```
``````
